### PR TITLE
Mobile Web3 Wallets Compatibility and Other Small Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,13 @@
 
 		<link rel="stylesheet" href="css/main.css">
 		
-		
 		<script src="https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js"></script>
 		<script src="https://unpkg.com/vue@2.5.17/dist/vue.min.js"></script>
 		<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 
+		<script type="text/javascript" src="https://unpkg.com/web3modal@1.9.0/dist/index.js"></script>
+		<script type="text/javascript" src="https://unpkg.com/evm-chains@0.2.0/dist/umd/index.min.js"></script>
+		<script type="text/javascript" src="https://unpkg.com/@walletconnect/web3-provider@1.2.1/dist/umd/index.min.js"></script>
 	</head>
 
 	<body>
@@ -37,16 +39,13 @@
 						Click the button to (sign up and) login!
 					</div>
 					<div v-show="state == 'needMetamask'" class="msg-info">
-						To login, first install the <a href="https://metamask.io/" style="color:#ff7300" target="_blank">MetaMask</a> browser extension
-					</div>
-					<div v-show="state == 'mobileDevice'" class="msg-info">
-						This login system doesn't work on mobiles because it requires <a href="https://metamask.io/" style="color:#ff7300" target="_blank">MetaMask</a> browser extension
+						To login, first install a Web3 wallet like the <a href="https://metamask.io/" style="color:#ff7300" target="_blank">MetaMask</a> browser extension or mobile app
 					</div>
 					<div v-show="state == 'needLogInToMetaMask'" class="msg-info">
-						Log in to your MetaMask account first!
+						Log in to your wallet account first!
 					</div>
 					<div v-show="state == 'signTheMessage'">
-						Sign the message in MetaMask to authenticate
+						Sign the message with your wallet to authenticate
 					</div>
 					<div v-show="state == 'loggedIn'">
 						Successful authentication for address:<br>{{ ethAddress }}
@@ -68,14 +67,8 @@
 
 		</div>
 
-
-		<script>
-			if (window.web3) {
-				const web3 = new Web3(window.web3.currentProvider);
-			} 
-		</script>
-
 		<script src="js/main.js?v=003"></script>
+		<script src="js/web3-modal.js"></script>
 
 	</body>
 

--- a/js/main.js
+++ b/js/main.js
@@ -10,10 +10,12 @@ var app = new Vue({
   },
   methods: {
     logInOut: async function() {
-      if (window.web3) {
-        window.web3 = new Web3(ethereum);
+      if(this.state == "loggedOut") {
+        await onConnectLoadWeb3Modal();
+      }
+      if (web3ModalProv) {
+        window.web3 = web3ModalProv;
         try {
-          this.accounts = await ethereum.enable();
           this.login();
         } catch (error) {
           console.log(error);
@@ -34,16 +36,13 @@ var app = new Vue({
         vm.buttonText = "Log in";
         return;
       }
-      if ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
-        vm.state = "mobileDevice";
-        return;
-      }
       if (typeof window.web3 === "undefined") {
         vm.state = "needMetamask";
         return;
       }
-      let accountsOnEnable = await ethereum.request({method: 'eth_requestAccounts'});
+      let accountsOnEnable = await web3.eth.getAccounts();
       let address = accountsOnEnable[0];
+      address = address.toLowerCase();
       if (address == null) {
         vm.state = "needLogInToMetaMask";
         return;
@@ -95,6 +94,8 @@ var app = new Vue({
                   vm.ethAddress = address;
                   vm.publicName = response.data[1];
                   vm.JWT = response.data[2];
+                  // Clear Web3 wallets data for logout
+                  localStorage.clear();
                 }
               })
               .catch(function(error) {
@@ -144,8 +145,9 @@ var app = new Vue({
       ethereum.on('accountsChanged', (_chainId) => ethNetworkUpdate());
 
       async function ethNetworkUpdate() {      
-        let accountsOnEnable = await ethereum.request({method: 'eth_requestAccounts'});
+        let accountsOnEnable = await web3.eth.getAccounts();
         let address = accountsOnEnable[0];
+        address = address.toLowerCase();
         if (vm.ethAddress != address) {
           vm.ethAddress = address;
           if (vm.state == "loggedIn") {

--- a/js/web3-modal.js
+++ b/js/web3-modal.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const Web3Modal = window.Web3Modal.default;
+const WalletConnectProvider = window.WalletConnectProvider.default;
+
+// Web3modal instance
+let web3Modal
+
+// Chosen wallet provider given by the dialog window
+let provider;
+
+// Address of the selected account
+let selectedAccount;
+
+// Web3Loaded
+let web3ModalProv;
+
+function web3ModalInit() {
+  // Tell Web3modal what providers we have available.
+  // Built-in web browser provider (only one can exist as a time)
+  // like MetaMask, Brave or Opera is added automatically by Web3modal
+  const providerOptions = {
+    walletconnect: {
+      package: WalletConnectProvider,
+      options: {
+        // Mikko's test key - don't copy as your mileage may vary
+        infuraId: "8043bb2cf99347b1bfadfb233c5325c0",
+      }
+    },
+  };
+
+  web3Modal = new Web3Modal({
+    cacheProvider: false, // optional
+    providerOptions, // required
+    disableInjectedProvider: false, // optional. For MetaMask / Brave / Opera.
+  });
+}
+
+async function fetchAccountData() {
+  web3ModalProv = new Web3(provider);
+ 
+  // Subscribe to accounts change
+  provider.on("accountsChanged", (accounts) => {
+    console.log(accounts);
+  });
+
+  // Subscribe to chainId change
+  provider.on("chainChanged", (chainId) => {
+    console.log(chainId);
+  });
+
+  // Subscribe to session disconnection
+  provider.on("disconnect", (code, reason) => {
+    console.log(code, reason);
+  });
+}
+
+async function refreshAccountData() {
+  await fetchAccountData(provider);
+}
+
+async function onConnectLoadWeb3Modal() {
+
+  try {
+    provider = await web3Modal.connect();
+  } catch(e) {
+    console.log("Could not get a wallet connection", e);
+    return;
+  }
+
+  await refreshAccountData();
+}
+
+window.addEventListener('load', async () => {
+  web3ModalInit();
+});

--- a/server/ajax.php
+++ b/server/ajax.php
@@ -14,6 +14,11 @@ require_once('config.php');
 $data = json_decode(file_get_contents("php://input"));
 $request = $data->request;
 
+// Create a standard of eth address by lowercasing them
+// Some wallets send address with upper and lower case characters
+if (!empty($data->address)) {
+  $data->address = strtolower($data->address);
+}
 
 if ($request == "login") {
   $address = $data->address;

--- a/server/config.php
+++ b/server/config.php
@@ -2,8 +2,8 @@
 
 $servername = "localhost";
 $username = "root";
-$password = "";
-$dbname = "passwordless_login";
+$password = "root";
+$dbname = "contributions_db";
 
 // Create connection
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/server/lib/Elliptic/Curve/MontCurve/Point.php
+++ b/server/lib/Elliptic/Curve/MontCurve/Point.php
@@ -45,7 +45,7 @@ class Point extends \Elliptic\Curve\BaseCurve\Point
         if( $this->isInfinity() )
             return "<EC Point Infinity>";
         return "<EC Point x: " . $this->x->fromRed()->toString(16, 2) .
-            " z: " . $this->z->fromRed()->toString(16, 2) + ">";
+            " z: " . $this->z->fromRed()->toString(16, 2) . ">";
     }
 
     public function isInfinity() {


### PR DESCRIPTION
It now supports [82 web3 wallets ](https://registry.walletconnect.org/wallets) including Metamask that uses the [WalletConnect Protocol](https://walletconnect.org/). 

It has full mobile support; you can log in with the Metamask mobile app browser or any other mobile app that supports the WalletConnect Protocol like Rainbow, Trust Wallet, Ledger Live, Crypto.com, etc.

Extra fixes

- Lowercase address in JS and ajax.php for compatibility

- Fixed deprecated issue on MontCurve/Point.php

Notes

- Metamask Mobile app with browser works quickly

- Any other Web3 wallet with WalletConnect takes 10-60 seconds to connect and sign the message

